### PR TITLE
Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: release
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  GH_TOKEN: ${{ github.token }}
+
+jobs:
+  create_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create Release
+        run: |
+          gh release create ${{ github.ref_name }} \
+            -t ${{ github.ref_name }} \
+            -n "Release ${{ github.ref_name }}"
+
+  release:
+    runs-on: ubuntu-latest
+    needs: create_release
+    strategy:
+      fail-fast: false
+      matrix:
+        dir:
+          - ce.hashima
+          - empty.hashima
+          - main.hashima
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: 'true'
+        
+      - run: git lfs pull
+
+      - name: Zip ${{ matrix.dir }}
+        run: zip -r ${{ matrix.dir }}.zip ${{ matrix.dir }}
+
+      - name: Upload ${{ matrix.dir }}
+        run: gh release upload ${{ github.ref_name }} ${{ matrix.dir }}.zip
+
+  release_areaflags:
+    runs-on: ubuntu-latest
+    needs: create_release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: 'true'
+        
+      - run: git lfs pull
+
+      - name: Upload Area Flags
+        run: gh release upload ${{ github.ref_name }} main.hashima/areaflags.map
+
+      - name: Hash Area Flags
+        run: sha256sum main.hashima/areaflags.map > main.hashima/areaflags.map.sha256
+
+      - name: Upload Hash
+        run: gh release upload ${{ github.ref_name }} main.hashima/areaflags.map.sha256
+

--- a/README.md
+++ b/README.md
@@ -126,9 +126,10 @@ profiles/
 
 **[Download files (.zip) 🡥](https://github.com/hashimagg/mission/archive/refs/heads/main.zip)**
 
-**[Download areaflags.map 🡥](https://github.com/hashimagg/mission/raw/refs/heads/main/main.hashima/areaflags.map)**
+**[Download areaflags.map 🡥](https://github.com/hashimagg/mission/releases/latest/download/areaflags.map)**
 
 <small>Replace the areaflags.map inside `main.hashima`</small>
+<small>Version specific areaflag.map can be found on the [releases](https://github.com/jsirianni/mission/releases) page.</small>
 
 ## Server Setup
 


### PR DESCRIPTION
I thought this might be useful after viewing https://github.com/hashimagg/mission/issues/1

Added a simple release workflow that will create a release when a new tag is created or pushed.
- Zips and uploads the three directories
- Uploads areamap
- Checksums and uploads areamap.

Also updated the readme to link to the latest release.

If you do not wish to have this, no hard feelings :+1: 